### PR TITLE
Added instructions about port forwarding ports 3000 and 8000 to the host system

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,13 @@ boot2docker init
 boot2docker start
 ```
 
+In order access the applications on ports 3000 and 8000 on the host system, you will need to port forward ports 3000 and 8000 through VirtualBox from the boot2docker image to the host system.
+
+Go to VirtualBox > boot2docker-vm > Settings > Network > Port Forwarding and add the following rules:
+
+1. Protocol:TCP, Host Ip:127.0.0.1, Host Port:3000, Guest Port:3000
+2. Protocol:TCP, Host Ip:127.0.0.1, Host Port:8000, Guest Port:8000
+
 Then continue the setup as described above.
 
 ## Setup - non-docker way


### PR DESCRIPTION
Hi,

When I followed the instructions to setup the docker image and hit ports 3000 and 8000 on my Mac, I noticed that I could not access the applications. I then remembered that boot2docker runs a linux VM and and any ports forwarded from docker only affect this linux VM and not MacOSX itself. After I added port forwarding for ports 3000 and 8000 in my VirtualBox for the boot2docker-vm, everything seemed to work.

I've added instructions on how to port forward these ports to the README, when using MacOSX.
